### PR TITLE
MACE

### DIFF
--- a/configs/s2ef/2M/mace/012702_128x0e_128x1o_128x2e.yml
+++ b/configs/s2ef/2M/mace/012702_128x0e_128x1o_128x2e.yml
@@ -3,65 +3,52 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: lmdb
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
-  # OCP MACE models have "z2idx", which is missing in official MACE models.
-  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
-  # which are missing in OCP MACE models. Hence we set strict_load = False.
-  strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
-    total_energy: True
-    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
     normalize_labels: False
     # target_mean: -0.7554450631141663
     # target_std: 2.887317180633545
     # grad_target_mean: 0.0
     # grad_target_std: 2.887317180633545
-    # ase_nbrlist: True
-    # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
-    total_energy: True
-    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
-    # ase_nbrlist: True
-    # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
 
 model:
   name: scaleshift_mace
-  r_max: 8.0
-  max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  avg_num_neighbors: 35
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
-  num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
-  MLP_irreps: 16x0e
-  correlation: 3
+  num_interactions: 3
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 128x0e
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
-  # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
-  # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  correlation: 3
+  atomic_inter_shift: -0.75544
+  atomic_inter_scale: 2.88732
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 8
+  eval_batch_size: 8
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
-  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  # Default in MACE (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  # was 1.e-2.
   lr_initial: 1.e-2
   optimizer: AdamW
   optimizer_params: {"amsgrad": True}
@@ -74,14 +61,16 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
-  force_coefficient: 1000
-  energy_coefficient: 37
+  force_coefficient: 100
+  energy_coefficient: 1
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
   ema_decay: 0.99
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
   clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
   weight_decay: 5.e-7
 

--- a/configs/s2ef/2M/mace/013101_correct_scaleshift_weight_decay.yml
+++ b/configs/s2ef/2M/mace/013101_correct_scaleshift_weight_decay.yml
@@ -1,0 +1,78 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  avg_num_neighbors: 35
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 3
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 128x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  atomic_inter_shift: -0.01030613915
+  atomic_inter_scale: 0.2251
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 16
+  eval_batch_size: 16
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # Default in MACE (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  # was 1.e-2.
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 1.e-10
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/013102_128x0e_128x1o_128x2e.yml
+++ b/configs/s2ef/2M/mace/013102_128x0e_128x1o_128x2e.yml
@@ -1,0 +1,78 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  avg_num_neighbors: 35
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 3
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 128x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  atomic_inter_shift: -0.01030613915
+  atomic_inter_scale: 0.2251
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # Default in MACE (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  # was 1.e-2.
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 1.e-10
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/013102_128x0e_128x1o_128x2e.yml
+++ b/configs/s2ef/2M/mace/013102_128x0e_128x1o_128x2e.yml
@@ -34,8 +34,10 @@ model:
   MLP_irreps: 128x0e
   # atomic_energies: ref energy per atomic number.
   correlation: 3
-  atomic_inter_shift: -0.01030613915
-  atomic_inter_scale: 0.2251
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.0106
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4263
   # OCP flags.
   regress_forces: True
   otf_graph: True

--- a/configs/s2ef/2M/mace/013103_h256.yml
+++ b/configs/s2ef/2M/mace/013103_h256.yml
@@ -30,8 +30,8 @@ model:
   max_ell: 3
   num_interactions: 3
   num_elements: 83
-  hidden_irreps: 128x0e + 128x1o
-  MLP_irreps: 128x0e
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
   # atomic_energies: ref energy per atomic number.
   correlation: 3
   # torch.div(energies, natoms).mean()
@@ -44,8 +44,8 @@ model:
   use_pbc: True
 
 optim:
-  batch_size: 16
-  eval_batch_size: 16
+  batch_size: 4
+  eval_batch_size: 4
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2

--- a/configs/s2ef/2M/mace/032202_bugfixed.yml
+++ b/configs/s2ef/2M/mace/032202_bugfixed.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
   r_max: 8.0
   max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  avg_num_neighbors: 72.44458770751953
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.033861486108663866
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37

--- a/configs/s2ef/2M/mace/032501_wd1e-10.yml
+++ b/configs/s2ef/2M/mace/032501_wd1e-10.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
   r_max: 8.0
   max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  avg_num_neighbors: 72.44458770751953
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.033861486108663866
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37
@@ -83,7 +83,7 @@ optim:
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
   clip_grad_norm: 10
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
-  weight_decay: 5.e-7
+  weight_decay: 1.e-10
 
 slurm:
   constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/032502_ef_lr_switch_ft.yml
+++ b/configs/s2ef/2M/mace/032502_ef_lr_switch_ft.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
   r_max: 8.0
   max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  avg_num_neighbors: 72.44458770751953
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.033861486108663866
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,10 +74,10 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
-  force_coefficient: 1000
-  energy_coefficient: 37
+  force_coefficient: 1
+  energy_coefficient: 1000
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
   ema_decay: 0.99
   # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321

--- a/configs/s2ef/2M/mace/032503_MLP_irreps_128x0e.yml
+++ b/configs/s2ef/2M/mace/032503_MLP_irreps_128x0e.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
   r_max: 8.0
   max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  avg_num_neighbors: 72.44458770751953
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
-  MLP_irreps: 16x0e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 128x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.033861486108663866
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37

--- a/configs/s2ef/2M/mace/033001_bugfixed_nbrs30.yml
+++ b/configs/s2ef/2M/mace/033001_bugfixed_nbrs30.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
-  r_max: 8.0
-  max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.03386107087135315
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37

--- a/configs/s2ef/2M/mace/033002_bugfixed_nbrs20.yml
+++ b/configs/s2ef/2M/mace/033002_bugfixed_nbrs20.yml
@@ -3,9 +3,9 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
-  train_on_free_atoms: False
+  train_on_free_atoms: True
   eval_on_free_atoms: True
   # OCP MACE models have "z2idx", which is missing in official MACE models.
   # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
-  r_max: 8.0
-  max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  r_max: 12.0
+  max_neighbors: 20
+  avg_num_neighbors: 20
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.03386107087135315
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37

--- a/configs/s2ef/2M/mace/033003_bugfixed_nbrs30_allatoms.yml
+++ b/configs/s2ef/2M/mace/033003_bugfixed_nbrs30_allatoms.yml
@@ -3,7 +3,7 @@ trainer: mace_trainer
 logger: wandb
 
 task:
-  dataset: lmdb  # for training on total energies.
+  dataset: oc22_lmdb  # for training on total energies.
   primary_metric: forces_mae
   train_on_free_atoms: False
   eval_on_free_atoms: True
@@ -13,7 +13,7 @@ task:
   strict_load: False
 
 dataset:
-  - src: /checkpoint/bmwood/oc20_small/oc20_xxs_dataset/tot_e_lmdb/train/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
@@ -24,40 +24,40 @@ dataset:
     # grad_target_std: 2.887317180633545
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
     # ase_nbrlist: True
     # ase_cutoff: 8.0
-  # - src: /checkpoint/bmwood/oc20_small/oc20_xs_dataset/tot_e_lmdb/val/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:
   name: scaleshift_mace
-  r_max: 8.0
-  max_neighbors: 500
-  avg_num_neighbors: 16.268049240112305
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
   num_bessel: 8
   num_polynomial_cutoff: 5
   max_ell: 3
   num_interactions: 2
-  num_elements: 5
-  hidden_irreps: 256x0e + 256x1o + 256x2e
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
   MLP_irreps: 16x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
-  atomic_energies: oc20xxs
+  atomic_energies: oc20
   # torch.div(energies, natoms).mean()
-  atomic_inter_shift: 0.0046684232644386295
+  atomic_inter_shift: 0.03386107087135315
   # torch.sqrt(torch.mean(torch.square(forces)))
-  atomic_inter_scale: 0.37896862626075745
+  atomic_inter_scale: 0.4365839660167694
   # OCP flags.
   regress_forces: True
   otf_graph: True
   use_pbc: True
 
 optim:
-  batch_size: 32
-  eval_batch_size: 32
+  batch_size: 6
+  eval_batch_size: 6
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2
@@ -74,7 +74,7 @@ optim:
   # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
   # And so we should probably keep a lower patience. Using default from OCP for now.
   patience: 3
-  max_epochs: 1000
+  max_epochs: 40
   # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
   force_coefficient: 1000
   energy_coefficient: 37

--- a/configs/s2ef/2M/mace/033101_nbrs30_maxell4.yml
+++ b/configs/s2ef/2M/mace/033101_nbrs30_maxell4.yml
@@ -1,0 +1,89 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 4
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 6
+  eval_batch_size: 6
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/033102_nbrs30_adam_wd5e-10.yml
+++ b/configs/s2ef/2M/mace/033102_nbrs30_adam_wd5e-10.yml
@@ -1,0 +1,89 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 6
+  eval_batch_size: 6
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: Adam
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-10
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/033103_nbrs30_adam_wd5e-7.yml
+++ b/configs/s2ef/2M/mace/033103_nbrs30_adam_wd5e-7.yml
@@ -1,0 +1,89 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 6
+  eval_batch_size: 6
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: Adam
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040302_nbrs30_gaussian.yml
+++ b/configs/s2ef/2M/mace/040302_nbrs30_gaussian.yml
@@ -1,0 +1,91 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 6
+  eval_batch_size: 6
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040501_nbrs30_adam_wd0.yml
+++ b/configs/s2ef/2M/mace/040501_nbrs30_adam_wd0.yml
@@ -1,0 +1,89 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 6
+  eval_batch_size: 6
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: Adam
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 0.
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040502_nbrs30_gaussian_rbfh256.yml
+++ b/configs/s2ef/2M/mace/040502_nbrs30_gaussian_rbfh256.yml
@@ -1,0 +1,92 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 128x0e + 128x1o + 128x2e
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 12
+  eval_batch_size: 12
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040503_nbrs30_gaussian_h512_mlp128_rbfh256.yml
+++ b/configs/s2ef/2M/mace/040503_nbrs30_gaussian_h512_mlp128_rbfh256.yml
@@ -1,0 +1,92 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 4
+  eval_batch_size: 4
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040601_h1024_mlp128_rbfh256.yml
+++ b/configs/s2ef/2M/mace/040601_h1024_mlp128_rbfh256.yml
@@ -1,0 +1,92 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 1024x0e + 1024x1o + 1024x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: 0.03386107087135315
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.4365839660167694
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 1
+  eval_batch_size: 1
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040602_h512_mlp128_rbfh256_direct.yml
+++ b/configs/s2ef/2M/mace/040602_h512_mlp128_rbfh256_direct.yml
@@ -44,7 +44,7 @@ model:
   max_ell: 3
   num_interactions: 2
   num_elements: 56
-  hidden_irreps: 1024x0e + 1024x1o + 1024x2e
+  hidden_irreps: 512x0e + 512x1o + 512x2e
   MLP_irreps: 128x0e
   correlation: 3
   # atomic_energies: ref energy per atomic number.
@@ -57,10 +57,11 @@ model:
   regress_forces: True
   otf_graph: True
   use_pbc: True
+  direct_forces: True
 
 optim:
-  batch_size: 2
-  eval_batch_size: 2
+  batch_size: 8
+  eval_batch_size: 8
   load_balancing: atoms
   eval_every: 1000
   num_workers: 2

--- a/configs/s2ef/2M/mace/040701_h512_mlp128_rbfh256_direct_intenergies.yml
+++ b/configs/s2ef/2M/mace/040701_h512_mlp128_rbfh256_direct_intenergies.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040801_intenergies_maxell4.yml
+++ b/configs/s2ef/2M/mace/040801_intenergies_maxell4.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 4
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 4
+  eval_batch_size: 4
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040802_wd1e-2.yml
+++ b/configs/s2ef/2M/mace/040802_wd1e-2.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 0.01
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/040803_allatoms_0.1_1_1.yml
+++ b/configs/s2ef/2M/mace/040803_allatoms_0.1_1_1.yml
@@ -1,0 +1,88 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  tag_specific_weights:
+    - 0.1
+    - 1.0
+    - 1.0
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+  loss_force: l2mae
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/041201_speciesagnostic.yml
+++ b/configs/s2ef/2M/mace/041201_speciesagnostic.yml
@@ -1,0 +1,87 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticInteractionBlock
+  interaction_cls: SpeciesAgnosticInteractionBlock
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/041801_specagn_withskip.yml
+++ b/configs/s2ef/2M/mace/041801_specagn_withskip.yml
@@ -1,0 +1,87 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+    # ase_nbrlist: True
+    # ase_cutoff: 8.0
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: SpeciesAgnosticResidualInteractionBlock
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/042401_srctgt_conv.yml
+++ b/configs/s2ef/2M/mace/042401_srctgt_conv.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: SpeciesAgnosticResidualInteractionBlock
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/042501_srctgt_conv_gradclip5.yml
+++ b/configs/s2ef/2M/mace/042501_srctgt_conv_gradclip5.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: SpeciesAgnosticResidualInteractionBlock
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 5
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/050101_srctgt_conv_h256.yml
+++ b/configs/s2ef/2M/mace/050101_srctgt_conv_h256.yml
@@ -1,0 +1,85 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: SpeciesAgnosticResidualInteractionBlock
+  contraction_type: v2
+  node_feats_down_irreps: 256x0e
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 5
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/050102_specdep_srctgt_conv.yml
+++ b/configs/s2ef/2M/mace/050102_specdep_srctgt_conv.yml
@@ -1,0 +1,85 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: RealAgnosticResidualInteractionBlockV2
+  interaction_cls: RealAgnosticResidualInteractionBlockV2
+  contraction_type: v1
+  node_feats_down_irreps: 64x0e
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 8
+  eval_batch_size: 8
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/082201_edgegated.yml
+++ b/configs/s2ef/2M/mace/082201_edgegated.yml
@@ -1,0 +1,84 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: EdgeGatedInteractionBlock
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 4
+  eval_batch_size: 4
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 5
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/103101_edgegated_srctgt.yml
+++ b/configs/s2ef/2M/mace/103101_edgegated_srctgt.yml
@@ -44,6 +44,8 @@ model:
   interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
   interaction_cls: EdgeGatedInteractionBlock
   edge_gates_irreps: 128x0e
+  edge_gates_use_source_target_feats: True
+  node_feats_down_irreps: 64x0e
   contraction_type: v2
   # OCP flags.
   regress_forces: True

--- a/configs/s2ef/2M/mace/110501_edgegated_srctgt_h512.yml
+++ b/configs/s2ef/2M/mace/110501_edgegated_srctgt_h512.yml
@@ -1,0 +1,87 @@
+trainer: interaction_mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  train:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    normalize_labels: True
+    target_mean: -0.7554450631141663
+    target_std: 2.887317180633545
+    grad_target_mean: 0.0
+    grad_target_std: 2.887317180633545
+  val:
+    src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: interaction_energy_mace
+  r_max: 12.0
+  max_neighbors: 30
+  avg_num_neighbors: 30
+  rbf: gaussian
+  num_rbf: 128
+  rbf_hidden_channels: 256
+  num_bessel: -1  # unused, but required.
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 56
+  hidden_irreps: 512x0e + 512x1o + 512x2e
+  MLP_irreps: 128x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20
+  interaction_cls_first: SpeciesAgnosticResidualInteractionBlock
+  interaction_cls: EdgeGatedInteractionBlock
+  edge_gates_irreps: 128x0e
+  edge_gates_use_source_target_feats: True
+  node_feats_down_irreps: 64x0e
+  contraction_type: v2
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+  direct_forces: True
+
+optim:
+  batch_size: 2
+  eval_batch_size: 2
+  load_balancing: atoms
+  eval_every: 2000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 5
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/2M/mace/base_0127.yml
+++ b/configs/s2ef/2M/mace/base_0127.yml
@@ -1,0 +1,78 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/train/2M
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /datasets01/open_catalyst/oc20/082422/struct_to_energy_forces/val/id_30k
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  avg_num_neighbors: 35
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 3
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 128x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  atomic_inter_shift: -0.75544
+  atomic_inter_scale: 2.88732
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 16
+  eval_batch_size: 16
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # Default in MACE (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  # was 1.e-2.
+  lr_initial: 5.e-3
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 40
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/020101.yml
+++ b/configs/s2ef/tiny/mace/020101.yml
@@ -1,0 +1,80 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/train/ads_energy
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/val/ads_energy
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  avg_num_neighbors: 35
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 128x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.08374
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 64
+  eval_batch_size: 64
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/020102_exact_nbrs.yml
+++ b/configs/s2ef/tiny/mace/020102_exact_nbrs.yml
@@ -1,0 +1,81 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/train/ads_energy
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/val/ads_energy
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: -1
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 128x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.08374
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/020103_exact_nbrs_h256.yml
+++ b/configs/s2ef/tiny/mace/020103_exact_nbrs_h256.yml
@@ -1,0 +1,81 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: -1
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.08374
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/020104_nbrs31_h256.yml
+++ b/configs/s2ef/tiny/mace/020104_nbrs31_h256.yml
@@ -1,0 +1,81 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: 31
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.08374
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 100
+  energy_coefficient: 1
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  loss_energy: mae
+  loss_force: l2mae
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/020105_nbrs31_h256_f1000_e37.yml
+++ b/configs/s2ef/tiny/mace/020105_nbrs31_h256_f1000_e37.yml
@@ -1,0 +1,79 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: lmdb
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: 31
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
+  # atomic_energies: ref energy per atomic number.
+  correlation: 3
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -0.08374
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/021801_total_energy.yml
+++ b/configs/s2ef/tiny/mace/021801_total_energy.yml
@@ -1,0 +1,84 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: 31
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 83
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20tiny
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -7.1012316731649495e-15
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462538421154022
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/022101_total_energy_zembedfix.yml
+++ b/configs/s2ef/tiny/mace/022101_total_energy_zembedfix.yml
@@ -1,0 +1,84 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: 31
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 5
+  hidden_irreps: 256x0e + 256x1o
+  MLP_irreps: 256x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20tiny
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -7.1012316731649495e-15
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462538421154022
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 32
+  eval_batch_size: 32
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/022201_total_energy_h128_mlp16.yml
+++ b/configs/s2ef/tiny/mace/022201_total_energy_h128_mlp16.yml
@@ -1,0 +1,84 @@
+trainer: mace_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  # Copied from https://github.com/ACEsuit/mace#training.
+  r_max: 6.0 # was originally 5.0
+  # Use `avg_num_neighbors` = 50 if r_max is 12.0, 35 if r_max is 6.0.
+  # This is because max_neighbors is set to 50. At r_max = 12, we get all nbrs.
+  # Passing -1 computes exact no. neighbors per system.
+  avg_num_neighbors: 31
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 5
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20tiny
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -7.1012316731649495e-15
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462538421154022
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 64
+  eval_batch_size: 64
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/022202_ilyes_weights.yml
+++ b/configs/s2ef/tiny/mace/022202_ilyes_weights.yml
@@ -1,0 +1,84 @@
+trainer: eval_mace_chkpts_trainer
+
+logger: wandb
+
+task:
+  dataset: oc22_lmdb  # for training on total energies.
+  primary_metric: forces_mae
+  train_on_free_atoms: True
+  eval_on_free_atoms: True
+  # OCP MACE models have "z2idx", which is missing in official MACE models.
+  # Official MACE models have "atomic_numbers", "r_max", "num_interactions",
+  # which are missing in OCP MACE models. Hence we set strict_load = False.
+  strict_load: False
+
+dataset:
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/train/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # Switch off normalize_labels since scale_shift in the MACE model does the same thing.
+    normalize_labels: False
+    # target_mean: -0.7554450631141663
+    # target_std: 2.887317180633545
+    # grad_target_mean: 0.0
+    # grad_target_std: 2.887317180633545
+  - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
+    total_energy: True
+    oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+  # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
+
+model:
+  name: scaleshift_mace
+  r_max: 5.0
+  avg_num_neighbors: 15.3386
+  num_bessel: 8
+  num_polynomial_cutoff: 5
+  max_ell: 3
+  num_interactions: 2
+  num_elements: 5
+  hidden_irreps: 128x0e + 128x1o
+  MLP_irreps: 16x0e
+  correlation: 3
+  # atomic_energies: ref energy per atomic number.
+  atomic_energies: oc20tiny
+  # torch.div(energies, natoms).mean()
+  atomic_inter_shift: -7.1012316731649495e-15
+  # torch.sqrt(torch.mean(torch.square(forces)))
+  atomic_inter_scale: 0.23462538421154022
+  # OCP flags.
+  regress_forces: True
+  otf_graph: True
+  use_pbc: True
+
+optim:
+  batch_size: 64
+  eval_batch_size: 64
+  load_balancing: atoms
+  eval_every: 1000
+  num_workers: 2
+  # default from (https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L234)
+  lr_initial: 1.e-2
+  optimizer: AdamW
+  optimizer_params: {"amsgrad": True}
+  scheduler: ReduceLROnPlateau
+  mode: min
+  factor: 0.8
+  # In the MACE code, the RLROP scheduler is run every epoch even if validation loss is stale.
+  # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/mace/tools/train.py#L149
+  # In the OCP code, we step the scheduler only when validation loss is recomputed.
+  # https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/trainers/forces_trainer.py#L412
+  # And so we should probably keep a lower patience. Using default from OCP for now.
+  patience: 3
+  max_epochs: 1000
+  # TODO(@abhshkdz): implement the swa scheduler, i.e. switch to high energy coefficient and low force coefficient after loss plateaus with initial coefficients.
+  force_coefficient: 1000
+  energy_coefficient: 37
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285
+  ema_decay: 0.99
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321
+  clip_grad_norm: 10
+  # default from https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L240.
+  weight_decay: 5.e-7
+
+slurm:
+  constraint: "volta32gb"

--- a/configs/s2ef/tiny/mace/022202_ilyes_weights.yml
+++ b/configs/s2ef/tiny/mace/022202_ilyes_weights.yml
@@ -22,9 +22,13 @@ dataset:
     # target_std: 2.887317180633545
     # grad_target_mean: 0.0
     # grad_target_std: 2.887317180633545
+    # ase_nbrlist: True
+    # ase_cutoff: 5.0
   - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/v1_sid_str/val/ads_energy/
     total_energy: True
     oc20_ref: /checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl
+    # ase_nbrlist: True
+    # ase_cutoff: 5.0
   # - src: /checkpoint/bmwood/oc20_small/lmdbs/random1215212/test/ads_energy
 
 model:

--- a/ocpmodels/models/mace/blocks.py
+++ b/ocpmodels/models/mace/blocks.py
@@ -1,0 +1,337 @@
+from abc import ABC, abstractmethod
+from typing import Callable, Dict, Optional, Tuple, Union
+
+import numpy as np
+
+import torch
+import torch.nn.functional
+from e3nn import nn, o3
+
+from .mace_core.blocks import InteractionBlock
+from .mace_core.irreps_tools import (
+    linear_out_irreps,
+    reshape_irreps,
+    tp_out_irreps_with_instructions,
+)
+from .mace_core.scatter import scatter_sum
+from .mace_core.symmetric_contraction import SymmetricContraction
+
+from .radial import BesselBasis, PolynomialCutoff
+
+
+
+class LinearNodeEmbeddingBlock(torch.nn.Module):
+    def __init__(self, irreps_in: o3.Irreps, irreps_out: o3.Irreps):
+        super().__init__()
+        self.linear = o3.Linear(irreps_in=irreps_in, irreps_out=irreps_out)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,  # [n_nodes, irreps]
+    ):
+        return self.linear(node_attrs)
+
+
+class LinearReadoutBlock(torch.nn.Module):
+    def __init__(self, irreps_in: o3.Irreps):
+        super().__init__()
+        self.linear = o3.Linear(irreps_in=irreps_in, irreps_out=o3.Irreps("0e"))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
+        return self.linear(x)  # [n_nodes, 1]
+
+
+class NonLinearReadoutBlock(torch.nn.Module):
+    def __init__(
+        self, irreps_in: o3.Irreps, MLP_irreps: o3.Irreps, gate: Optional[Callable]
+    ):
+        super().__init__()
+        self.hidden_irreps = MLP_irreps
+        self.linear_1 = o3.Linear(irreps_in=irreps_in, irreps_out=self.hidden_irreps)
+        self.non_linearity = nn.Activation(irreps_in=self.hidden_irreps, acts=[gate])
+        self.linear_2 = o3.Linear(
+            irreps_in=self.hidden_irreps, irreps_out=o3.Irreps("0e")
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # [n_nodes, irreps]  # [..., ]
+        x = self.non_linearity(self.linear_1(x))
+        return self.linear_2(x)  # [n_nodes, 1]
+
+
+class AtomicEnergiesBlock(torch.nn.Module):
+    atomic_energies: torch.Tensor
+
+    def __init__(self, atomic_energies: Union[np.ndarray, torch.Tensor]):
+        super().__init__()
+        assert len(atomic_energies.shape) == 1
+
+        self.register_buffer(
+            "atomic_energies",
+            torch.tensor(atomic_energies, dtype=torch.get_default_dtype()),
+        )  # [n_elements, ]
+
+    def forward(
+        self, x: torch.Tensor  # one-hot of elements [..., n_elements]
+    ) -> torch.Tensor:  # [..., ]
+        return torch.matmul(x, self.atomic_energies)
+
+    def __repr__(self):
+        formatted_energies = ", ".join([f"{x:.4f}" for x in self.atomic_energies])
+        return f"{self.__class__.__name__}(energies=[{formatted_energies}])"
+
+
+class RadialEmbeddingBlock(torch.nn.Module):
+    def __init__(self, r_max: float, num_bessel: int, num_polynomial_cutoff: int):
+        super().__init__()
+        self.bessel_fn = BesselBasis(r_max=r_max, num_basis=num_bessel)
+        self.cutoff_fn = PolynomialCutoff(r_max=r_max, p=num_polynomial_cutoff)
+        self.out_dim = num_bessel
+
+    def forward(
+        self,
+        edge_lengths: torch.Tensor,  # [n_edges, 1]
+    ):
+        bessel = self.bessel_fn(edge_lengths)  # [n_edges, n_basis]
+        cutoff = self.cutoff_fn(edge_lengths)  # [n_edges, 1]
+        return bessel * cutoff  # [n_edges, n_basis]
+
+
+nonlinearities = {1: torch.nn.SiLU(), -1: torch.nn.Tanh()}
+
+
+class TensorProductWeightsBlock(torch.nn.Module):
+    def __init__(self, num_elements: int, num_edge_feats: int, num_feats_out: int):
+        super().__init__()
+
+        weights = torch.empty(
+            (num_elements, num_edge_feats, num_feats_out),
+            dtype=torch.get_default_dtype(),
+        )
+        torch.nn.init.xavier_uniform_(weights)
+        self.weights = torch.nn.Parameter(weights)
+
+    def forward(
+        self,
+        sender_or_receiver_node_attrs: torch.Tensor,  # assumes that the node attributes are one-hot encoded
+        edge_feats: torch.Tensor,
+    ):
+        return torch.einsum(
+            "be, ba, aek -> bk", edge_feats, sender_or_receiver_node_attrs, self.weights
+        )
+
+    def __repr__(self):
+        return (
+            f'{self.__class__.__name__}(shape=({", ".join(str(s) for s in self.weights.shape)}), '
+            f"weights={np.prod(self.weights.shape)})"
+        )
+
+
+class ResidualElementDependentInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+        self.conv_tp_weights = TensorProductWeightsBlock(
+            num_elements=self.node_attrs_irreps.num_irreps,
+            num_edge_feats=self.edge_feats_irreps.num_irreps,
+            num_feats_out=self.conv_tp.weight_numel,
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
+        self.irreps_out = self.irreps_out.simplify()
+        self.linear = o3.Linear(
+            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = o3.FullyConnectedTensorProduct(
+            self.node_feats_irreps, self.node_attrs_irreps, self.irreps_out
+        )
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        sender, receiver = edge_index
+        num_nodes = node_feats.shape[0]
+        sc = self.skip_tp(node_feats, node_attrs)
+        node_feats = self.linear_up(node_feats)
+        tp_weights = self.conv_tp_weights(node_attrs[sender], edge_feats)
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        return message + sc  # [n_nodes, irreps]
+
+
+class AgnosticNonlinearInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+
+        # Convolution weights
+        input_dim = self.edge_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim] + 3 * [64] + [self.conv_tp.weight_numel],
+            torch.nn.SiLU(),
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
+        self.irreps_out = self.irreps_out.simplify()
+        self.linear = o3.Linear(
+            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = o3.FullyConnectedTensorProduct(
+            self.irreps_out, self.node_attrs_irreps, self.irreps_out
+        )
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        sender, receiver = edge_index
+        num_nodes = node_feats.shape[0]
+        tp_weights = self.conv_tp_weights(edge_feats)
+        node_feats = self.linear_up(node_feats)
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        message = self.skip_tp(message, node_attrs)
+        return message  # [n_nodes, irreps]
+
+
+class AgnosticResidualNonlinearInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+        # First linear
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps, self.edge_attrs_irreps, self.target_irreps
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+
+        # Convolution weights
+        input_dim = self.edge_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim] + 3 * [64] + [self.conv_tp.weight_numel],
+            torch.nn.SiLU(),
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = linear_out_irreps(irreps_mid, self.target_irreps)
+        self.irreps_out = self.irreps_out.simplify()
+        self.linear = o3.Linear(
+            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = o3.FullyConnectedTensorProduct(
+            self.node_feats_irreps, self.node_attrs_irreps, self.irreps_out
+        )
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        sender, receiver = edge_index
+        num_nodes = node_feats.shape[0]
+        sc = self.skip_tp(node_feats, node_attrs)
+        node_feats = self.linear_up(node_feats)
+        tp_weights = self.conv_tp_weights(edge_feats)
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        message = message + sc
+        return message  # [n_nodes, irreps]
+
+
+class ScaleShiftBlock(torch.nn.Module):
+    def __init__(self, scale: float, shift: float):
+        super().__init__()
+        self.register_buffer(
+            "scale", torch.tensor(scale, dtype=torch.get_default_dtype())
+        )
+        self.register_buffer(
+            "shift", torch.tensor(shift, dtype=torch.get_default_dtype())
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.scale * x + self.shift
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(scale={self.scale:.6f}, shift={self.shift:.6f})"
+        )

--- a/ocpmodels/models/mace/blocks.py
+++ b/ocpmodels/models/mace/blocks.py
@@ -12,6 +12,7 @@ from .mace_core.irreps_tools import (
     linear_out_irreps,
     reshape_irreps,
     tp_out_irreps_with_instructions,
+    lifted_skip,
 )
 from .mace_core.scatter import scatter_sum
 from .mace_core.symmetric_contraction import SymmetricContraction
@@ -665,3 +666,177 @@ class RealAgnosticResidualInteractionBlockV2(InteractionBlock):
             self.reshape(message),
             sc,
         )  # [n_nodes, channels, (lmax + 1)**2]
+
+
+@compile_mode("script")
+class IdentityResidualInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+        # First linear
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+
+        # Convolution weights
+        input_dim = self.edge_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim] + 3 * [self.rbf_hidden_channels] + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = self.target_irreps
+        self.linear = o3.Linear(
+            irreps_mid, self.irreps_out, internal_weights=True, shared_weights=True
+        )
+        
+        self.skip = lifted_skip(self.node_feats_irreps, self.hidden_irreps)
+        self.reshape = reshape_irreps(self.irreps_out)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        num_nodes = node_feats.shape[0]
+        sc = self.skip(node_feats)
+        node_feats = self.linear_up(node_feats)
+        tp_weights = self.conv_tp_weights(edge_feats)
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        return (
+            self.reshape(message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]
+
+
+@compile_mode("script")
+class EdgeGatedInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+
+        # First linear
+        self.linear = o3.Linear(self.node_feats_irreps, self.node_feats_irreps)
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+        irreps_mid = irreps_mid.simplify()
+        self.message_dim = irreps_mid.dim
+        self.irreps_out = self.target_irreps
+
+        # Convolution weights
+        self.num_convs = self.num_gates if self.multi_conv else 1
+        input_dim = self.edge_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim] + 3 * [self.rbf_hidden_channels] + [self.conv_tp.weight_numel * self.num_convs],
+            torch.nn.functional.silu,
+        )
+
+        # Edge gating operations
+        if self.exponential:
+            self.scale = nn.FullyConnectedNet(
+                [self.edge_gates_irreps.dim] + 3 * [self.rbf_hidden_channels] + [1],
+                torch.nn.functional.silu,
+            )
+        self.alpha = o3.Linear(self.node_feats_irreps,  self.edge_gates_irreps)
+        self.gamma = o3.Linear(irreps_mid * self.num_convs, self.edge_gates_irreps)
+        self.mix = o3.FullyConnectedTensorProduct(
+            self.edge_gates_irreps, self.edge_gates_irreps, f"{self.num_gates}x0e"
+        )
+        self.project = o3.Linear(irreps_mid * self.num_gates, self.irreps_out)
+
+        self.skip = lifted_skip(self.node_feats_irreps, self.hidden_irreps)
+        self.reshape = reshape_irreps(self.irreps_out)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        num_nodes = node_feats.shape[0]
+        num_edges = edge_feats.shape[0]
+        sc = self.skip(node_feats)
+        node_feats = self.linear(node_feats)
+
+        tp_weights = (
+            self.conv_tp_weights(edge_feats)
+                .reshape(
+                    num_edges,
+                    self.num_convs,
+                    self.conv_tp.weight_numel
+                )
+        )
+        
+        mji = self.conv_tp(
+            node_feats[sender][:,None,:], 
+            edge_attrs[:,None,:], 
+            tp_weights
+        )  # [n_edges, n_convs, irreps]
+
+        # Gate edges
+        alphas, gammas = (
+            self.alpha(node_feats[receiver]),
+            self.gamma(mji.reshape(num_edges, self.message_dim * self.num_convs)),
+        )
+        gate = self.mix(alphas, gammas) # [n_edges, n_gates]
+        if self.exponential:
+            local_scale = torch.nn.functional.softplus(
+                self.scale(alphas)
+            )
+            gate = (gate / local_scale).exp()
+        all_gate = scatter_sum(src=gate, index=receiver, dim=0, dim_size=num_nodes)
+        gate = torch.nan_to_num(gate / all_gate[receiver]).unsqueeze(-1) # [n_edges, n_gates, 1]
+
+        message = scatter_sum(
+            src=(gate * mji), index=receiver, dim=0, dim_size=num_nodes
+        ) # [n_nodes, n_gates, irreps]
+        
+        message = message.reshape(num_nodes, self.message_dim * self.num_gates) # [n_nodes, irreps * n_gates]
+        message = self.project(message) # [n_nodes, irreps_out]
+        return (
+            self.reshape(message),
+            sc,
+        )
+

--- a/ocpmodels/models/mace/blocks.py
+++ b/ocpmodels/models/mace/blocks.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 import torch.nn.functional
 from e3nn import nn, o3
+from e3nn.util.jit import compile_mode
 
 from .mace_core.blocks import InteractionBlock
 from .mace_core.irreps_tools import (
@@ -472,3 +473,75 @@ class GatedEquivariantBlock(torch.nn.Module):
 
         x = self.act(x)
         return x, v
+
+
+@compile_mode("script")
+class SpeciesAgnosticInteractionBlock(InteractionBlock):
+    def _setup(self) -> None:
+        # First linear
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+
+        # Convolution weights
+        input_dim = self.edge_feats_irreps.num_irreps
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim]
+            + 3 * [self.rbf_hidden_channels]
+            + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = self.target_irreps
+        self.linear = o3.Linear(
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+        )
+
+        self.reshape = reshape_irreps(self.irreps_out)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> Tuple[torch.Tensor, None]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        num_nodes = node_feats.shape[0]
+        node_feats = self.linear_up(node_feats)
+        tp_weights = self.conv_tp_weights(edge_feats)
+        mji = self.conv_tp(
+            node_feats[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        return (
+            self.reshape(message),
+            None,
+        )  # [n_nodes, channels, (lmax + 1)**2]

--- a/ocpmodels/models/mace/blocks.py
+++ b/ocpmodels/models/mace/blocks.py
@@ -569,3 +569,99 @@ class SpeciesAgnosticResidualInteractionBlock(InteractionBlock):
             self.reshape(message),
             sc,
         )  # [n_nodes, channels, (lmax + 1)**2]
+
+
+@compile_mode("script")
+class RealAgnosticResidualInteractionBlockV2(InteractionBlock):
+    def _setup(self) -> None:
+
+        # First linear
+        self.linear_up = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        # TensorProduct
+        irreps_mid, instructions = tp_out_irreps_with_instructions(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            self.target_irreps,
+        )
+        self.conv_tp = o3.TensorProduct(
+            self.node_feats_irreps,
+            self.edge_attrs_irreps,
+            irreps_mid,
+            instructions=instructions,
+            shared_weights=False,
+            internal_weights=False,
+        )
+
+        # Convolution weights
+        self.linear_down = o3.Linear(
+            self.node_feats_irreps,
+            self.node_feats_down_irreps,
+            internal_weights=True,
+            shared_weights=True,
+        )
+        input_dim = (
+            self.edge_feats_irreps.num_irreps
+            + 2 * self.node_feats_down_irreps.num_irreps
+        )
+        self.conv_tp_weights = nn.FullyConnectedNet(
+            [input_dim]
+            + 3 * [self.rbf_hidden_channels]
+            + [self.conv_tp.weight_numel],
+            torch.nn.functional.silu,
+        )
+
+        # Linear
+        irreps_mid = irreps_mid.simplify()
+        self.irreps_out = self.target_irreps
+        self.linear = o3.Linear(
+            irreps_mid,
+            self.irreps_out,
+            internal_weights=True,
+            shared_weights=True,
+        )
+
+        # Selector TensorProduct
+        self.skip_tp = o3.FullyConnectedTensorProduct(
+            self.node_feats_irreps, self.node_attrs_irreps, self.hidden_irreps
+        )
+        self.reshape = reshape_irreps(self.irreps_out)
+
+    def forward(
+        self,
+        node_attrs: torch.Tensor,
+        node_feats: torch.Tensor,
+        edge_attrs: torch.Tensor,
+        edge_feats: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        sender = edge_index[0]
+        receiver = edge_index[1]
+        num_nodes = node_feats.shape[0]
+        sc = self.skip_tp(node_feats, node_attrs)
+        node_feats_up = self.linear_up(node_feats)
+        node_feats_down = self.linear_down(node_feats)
+        augmented_edge_feats = torch.cat(
+            [
+                edge_feats,
+                node_feats_down[sender],
+                node_feats_down[receiver],
+            ],
+            dim=-1,
+        )
+        tp_weights = self.conv_tp_weights(augmented_edge_feats)
+        mji = self.conv_tp(
+            node_feats_up[sender], edge_attrs, tp_weights
+        )  # [n_edges, irreps]
+        message = scatter_sum(
+            src=mji, index=receiver, dim=0, dim_size=num_nodes
+        )  # [n_nodes, irreps]
+        message = self.linear(message) / self.avg_num_neighbors
+        return (
+            self.reshape(message),
+            sc,
+        )  # [n_nodes, channels, (lmax + 1)**2]

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -181,6 +181,7 @@ class MACE(BaseModel):
         referring to hydrogen, 2nd to carbon and so on.
         """
         idx = self.z2idx[atomic_numbers]
+        assert torch.all(idx >= 0)
 
         atomic_numbers_1hot = torch.zeros(
             atomic_numbers.shape[0],

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -51,7 +51,7 @@ class MACE(BaseModel):
         atomic_energies=str,
         interaction_cls=RealAgnosticResidualInteractionBlock,
         interaction_cls_first=RealAgnosticResidualInteractionBlock,
-        max_neighbors: int = 50,
+        max_neighbors: int = 500,
         otf_graph: bool = True,
         use_pbc: bool = True,
         regress_forces: bool = True,

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -63,6 +63,8 @@ class MACE(BaseModel):
         direct_forces: bool = False,
         # support for species-agonstic contraction.
         contraction_type: str = "v1",
+        # source and target feature size when concatenating for edge conv.
+        node_feats_down_irreps: str = "64x0e",
     ):
         super().__init__()
         self.cutoff = self.r_max = r_max
@@ -146,6 +148,7 @@ class MACE(BaseModel):
             # this ~fixed statistic for OC20, or compute this value on-the-fly.
             avg_num_neighbors=avg_num_neighbors,
             rbf_hidden_channels=rbf_hidden_channels,
+            node_feats_down_irreps=o3.Irreps(node_feats_down_irreps),
         )
         self.interactions = torch.nn.ModuleList([inter])
 
@@ -187,6 +190,7 @@ class MACE(BaseModel):
                 hidden_irreps=hidden_irreps_out,
                 avg_num_neighbors=avg_num_neighbors,
                 rbf_hidden_channels=rbf_hidden_channels,
+                node_feats_down_irreps=o3.Irreps(node_feats_down_irreps),
             )
             self.interactions.append(inter)
             prod = EquivariantProductBasisBlock(
@@ -517,6 +521,8 @@ class InteractionEnergyMACE(MACE):
         direct_forces: bool = False,
         # support for species-agnostic contraction.
         contraction_type: str = "v1",
+        # source and target feature size when concatenating for edge conv.
+        node_feats_down_irreps: str = "64x0e",
     ):
         super().__init__(
             num_atoms,
@@ -546,6 +552,7 @@ class InteractionEnergyMACE(MACE):
             rbf_hidden_channels=rbf_hidden_channels,
             direct_forces=direct_forces,
             contraction_type=contraction_type,
+            node_feats_down_irreps=node_feats_down_irreps,
         )
         if self.direct_forces:
             self.force_readout = ForceBlock(o3.Irreps(hidden_irreps))

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -1,0 +1,396 @@
+from typing import Any, Callable, Dict, List, Optional, Type
+
+import numpy as np
+import torch
+from e3nn import o3
+
+from .mace_core.blocks import (
+    EquivariantProductBasisBlock,
+    RealAgnosticResidualInteractionBlock,
+    AgnosticInteractionBlock
+)
+from .mace_core.scatter import scatter_sum
+
+from .blocks import (
+    AtomicEnergiesBlock,
+    LinearNodeEmbeddingBlock,
+    LinearReadoutBlock,
+    NonLinearReadoutBlock,
+    RadialEmbeddingBlock,
+    ScaleShiftBlock,
+)
+from .utils import compute_forces
+
+from ocpmodels.common.registry import registry
+from ocpmodels.models.base import BaseModel
+from ocpmodels.common.utils import conditional_grad
+
+
+@registry.register_model("mace")
+class MACE(BaseModel):
+    def __init__(
+        self,
+        # Unused legacy OCP params.
+        num_atoms: Optional[int],
+        bond_feat_dim: int,
+        num_targets: int,
+        #
+        r_max: float,
+        num_bessel: int,
+        num_polynomial_cutoff: int,
+        max_ell: int,
+        num_interactions: int,
+        num_elements: int,
+        hidden_irreps: str,
+        MLP_irreps: str,
+        avg_num_neighbors: float,
+        correlation: int,
+        # Defaults from OCP / https://github.com/ACEsuit/mace/blob/main/scripts/run_train.py
+        gate=torch.nn.functional.silu,
+        # per-element energy references currently initialized to 0s.
+        atomic_energies=np.array([0.0 for i in range(83)]),
+        interaction_cls=RealAgnosticResidualInteractionBlock,
+        interaction_cls_first=AgnosticInteractionBlock,
+        max_neighbors: int = 50,
+        otf_graph: bool = True,
+        use_pbc: bool = True,
+        regress_forces: bool = True,
+    ):
+        super().__init__()
+        self.cutoff = self.r_max = r_max
+        self.avg_num_neighbors = avg_num_neighbors
+        self.max_neighbors = max_neighbors
+        self.otf_graph = otf_graph
+        self.use_pbc = use_pbc
+        self.regress_forces = regress_forces
+
+        # YAML loads them as strings, initialize them as o3.Irreps.
+        hidden_irreps = o3.Irreps(hidden_irreps)
+        MLP_irreps = o3.Irreps(MLP_irreps)
+
+        # Embedding
+        node_attr_irreps = o3.Irreps([(num_elements, (0, 1))])
+        node_feats_irreps = o3.Irreps([(hidden_irreps.count(o3.Irrep(0, 1)), (0, 1))])
+        self.node_embedding = LinearNodeEmbeddingBlock(
+            irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
+        )
+        self.radial_embedding = RadialEmbeddingBlock(
+            r_max=r_max,
+            num_bessel=num_bessel,
+            num_polynomial_cutoff=num_polynomial_cutoff,
+        )
+        edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
+
+        sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
+        num_features = hidden_irreps.count(o3.Irrep(0, 1))
+        interaction_irreps = (sh_irreps * num_features).sort()[0].simplify()
+        self.spherical_harmonics = o3.SphericalHarmonics(
+            sh_irreps, normalize=True, normalization="component"
+        )
+
+        # Interactions and readout
+        self.atomic_energies_fn = AtomicEnergiesBlock(atomic_energies)
+
+        inter = interaction_cls_first(
+            node_attrs_irreps=node_attr_irreps,
+            node_feats_irreps=node_feats_irreps,
+            edge_attrs_irreps=sh_irreps,
+            edge_feats_irreps=edge_feats_irreps,
+            target_irreps=interaction_irreps,
+            hidden_irreps=hidden_irreps,
+            # MACE considers a fixed `avg_num_neighbors`. We can either compute
+            # this ~fixed statistic for OC20, or compute this value on-the-fly.
+            avg_num_neighbors=avg_num_neighbors,
+        )
+        self.interactions = torch.nn.ModuleList([inter])
+
+        # Use the appropriate self connection at the first layer for proper E0
+        use_sc_first = False
+        if "Residual" in str(interaction_cls_first):
+            use_sc_first = True
+
+        node_feats_irreps_out = inter.target_irreps
+        prod = EquivariantProductBasisBlock(
+            node_feats_irreps=node_feats_irreps_out,
+            target_irreps=hidden_irreps,
+            correlation=correlation,
+            num_elements=num_elements,
+            use_sc=use_sc_first,
+        )
+        self.products = torch.nn.ModuleList([prod])
+
+        self.readouts = torch.nn.ModuleList()
+        self.readouts.append(LinearReadoutBlock(hidden_irreps))
+
+        for i in range(num_interactions - 1):
+            if i == num_interactions - 2:
+                hidden_irreps_out = str(
+                    hidden_irreps[0]
+                )  # Select only scalars for last layer
+            else:
+                hidden_irreps_out = hidden_irreps
+            inter = interaction_cls(
+                node_attrs_irreps=node_attr_irreps,
+                node_feats_irreps=hidden_irreps,
+                edge_attrs_irreps=sh_irreps,
+                edge_feats_irreps=edge_feats_irreps,
+                target_irreps=interaction_irreps,
+                hidden_irreps=hidden_irreps_out,
+                avg_num_neighbors=avg_num_neighbors,
+            )
+            self.interactions.append(inter)
+            prod = EquivariantProductBasisBlock(
+                node_feats_irreps=interaction_irreps,
+                target_irreps=hidden_irreps_out,
+                correlation=correlation,
+                num_elements=num_elements,
+                use_sc=True,
+            )
+            self.products.append(prod)
+            if i == num_interactions - 2:
+                self.readouts.append(
+                    NonLinearReadoutBlock(hidden_irreps_out, MLP_irreps, gate)
+                )
+            else:
+                self.readouts.append(LinearReadoutBlock(hidden_irreps))
+
+    @conditional_grad(torch.enable_grad())
+    def forward(self, data):
+
+        # TODO(@abhshkdz): Fit linear references per element from training data.
+        # These are currently initialized to 0.0.
+
+        # OCP prepro boilerplate.
+        pos = data.pos
+        batch = data.batch
+        atomic_numbers = data.atomic_numbers.long()
+        num_atoms = atomic_numbers.shape[0]
+        num_graphs = data.batch.max() + 1
+
+        # MACE computes forces via gradients.
+        pos.requires_grad_(True)
+
+        (
+            edge_index,
+            D_st,
+            distance_vec,
+            cell_offsets,
+            cell_offset_distances,
+            neighbors,
+        ) = self.generate_graph(data)
+        idx_s, idx_t = edge_index
+        ### OCP prepro ends.
+
+        # Atomic energies
+        #
+        # Comment(@abhshkdz): `data.node_attrs` is a 1-hot vector for each
+        # atomic number. `self.atomic_energies_fn` just matmuls the 1-hot
+        # vectors with the list of energies per atomic number, returning the
+        # energy per element.
+        #
+        # For OC20, we initialize these per-element energies to 0.0 since
+        # we don't really need linear referencing for adsorption energies?
+
+        atomic_numbers -= 1 # subtract 1 because our embeddings start from 0.
+        atomic_numbers_1hot = torch.zeros(
+            num_atoms,
+            len(self.atomic_energies_fn.atomic_energies),
+            device=atomic_numbers.device
+        ).scatter_(1, atomic_numbers.unsqueeze(1), 1.)
+
+        breakpoint()
+
+        node_e0 = self.atomic_energies_fn(atomic_numbers_1hot)
+        e0 = scatter_sum(
+            src=node_e0, index=data.batch, dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+
+        # Embeddings
+        node_feats = self.node_embedding(atomic_numbers_1hot)
+
+        # Comment(@abhshkdz): `lengths` here is same as `D_st`, and `vectors` is
+        # the same as `distance_vec` but pointing in the opposite direction.
+        # vectors, lengths = get_edge_vectors_and_lengths(
+        #     positions=data.positions, edge_index=data.edge_index, shifts=data.shifts
+        # )
+        lengths = D_st.view(-1, 1)
+        vectors = -distance_vec
+
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(lengths)
+
+        # Interactions
+        energies = [e0]
+        for interaction, product, readout in zip(
+            self.interactions, self.products, self.readouts
+        ):
+            # print((neighbors / data.natoms).mean(), self.avg_num_neighbors)
+            node_feats, sc = interaction(
+                node_attrs=atomic_numbers_1hot,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+            )
+            node_feats = product(
+                node_feats=node_feats, sc=sc, node_attrs=atomic_numbers_1hot
+            )
+            node_energies = readout(node_feats).squeeze(-1)  # [n_nodes, ]
+            energy = scatter_sum(
+                src=node_energies, index=data.batch, dim=-1, dim_size=num_graphs
+            )  # [n_graphs,]
+            energies.append(energy)
+
+        # Sum over energy contributions
+        contributions = torch.stack(energies, dim=-1)
+        total_energy = torch.sum(contributions, dim=-1)  # [n_graphs, ]
+
+        # Compute forces via autograd.
+        forces = compute_forces(
+            energy=total_energy, positions=pos, training=self.training
+        )
+
+        return total_energy, forces
+
+
+@registry.register_model("scaleshift_mace")
+class ScaleShiftMACE(MACE):
+    def __init__(
+        self,
+        # Unused legacy OCP params.
+        num_atoms: Optional[int],
+        bond_feat_dim: int,
+        num_targets: int,
+        #
+        r_max: float,
+        num_bessel: int,
+        num_polynomial_cutoff: int,
+        max_ell: int,
+        num_interactions: int,
+        num_elements: int,
+        hidden_irreps: str,
+        MLP_irreps: str,
+        avg_num_neighbors: float,
+        correlation: int,
+        atomic_inter_scale: float,
+        atomic_inter_shift: float,
+        # Defaults from OCP / https://github.com/ACEsuit/mace/blob/main/scripts/run_train.py
+        gate=torch.nn.functional.silu,
+        atomic_energies=np.array([0.0 for i in range(83)]),
+        interaction_cls=RealAgnosticResidualInteractionBlock,
+        interaction_cls_first=AgnosticInteractionBlock,
+        max_neighbors: int = 50,
+        otf_graph: bool = True,
+        use_pbc: bool = True,
+        regress_forces: bool = True,
+    ):
+        super().__init__(
+            num_atoms,
+            bond_feat_dim,
+            num_targets,
+            #
+            r_max,
+            num_bessel,
+            num_polynomial_cutoff,
+            max_ell,
+            num_interactions,
+            num_elements,
+            hidden_irreps,
+            MLP_irreps,
+            avg_num_neighbors,
+            correlation,
+        )
+        self.scale_shift = ScaleShiftBlock(
+            scale=atomic_inter_scale, shift=atomic_inter_shift
+        )
+
+    @conditional_grad(torch.enable_grad())
+    def forward(self, data):
+        # TODO(@abhshkdz): Fit linear references per element from training data.
+        # These are currently initialized to 0.0.
+
+        # OCP prepro boilerplate.
+        pos = data.pos
+        batch = data.batch
+        atomic_numbers = data.atomic_numbers.long()
+        num_atoms = atomic_numbers.shape[0]
+        num_graphs = data.batch.max() + 1
+
+        # MACE computes forces via gradients.
+        pos.requires_grad_(True)
+
+        (
+            edge_index,
+            D_st,
+            distance_vec,
+            cell_offsets,
+            cell_offset_distances,
+            neighbors,
+        ) = self.generate_graph(data)
+        idx_s, idx_t = edge_index
+        ### OCP prepro ends.
+
+        # Atomic energies
+        #
+        # Comment(@abhshkdz): `data.node_attrs` is a 1-hot vector for each
+        # atomic number. `self.atomic_energies_fn` just matmuls the 1-hot
+        # vectors with the list of energies per atomic number, returning the
+        # energy per element.
+        #
+        # For OC20, we initialize these per-element energies to 0.0 since
+        # we don't really need linear referencing for adsorption energies?
+
+        atomic_numbers -= 1 # subtract 1 because our embeddings start from 0.
+        atomic_numbers_1hot = torch.zeros(
+            num_atoms,
+            len(self.atomic_energies_fn.atomic_energies),
+            device=atomic_numbers.device
+        ).scatter_(1, atomic_numbers.unsqueeze(1), 1.)
+
+        node_e0 = self.atomic_energies_fn(atomic_numbers_1hot)
+        e0 = scatter_sum(
+            src=node_e0, index=data.batch, dim=-1, dim_size=num_graphs
+        )  # [n_graphs,]
+
+        # Embeddings
+        node_feats = self.node_embedding(atomic_numbers_1hot)
+        lengths = D_st.view(-1, 1)
+        vectors = -distance_vec
+        edge_attrs = self.spherical_harmonics(vectors)
+        edge_feats = self.radial_embedding(lengths)
+
+        # Interactions
+        node_es_list = []
+        for interaction, product, readout in zip(
+            self.interactions, self.products, self.readouts
+        ):
+            node_feats, sc = interaction(
+                node_attrs=atomic_numbers_1hot,
+                node_feats=node_feats,
+                edge_attrs=edge_attrs,
+                edge_feats=edge_feats,
+                edge_index=edge_index,
+            )
+            node_feats = product(
+                node_feats=node_feats, sc=sc, node_attrs=atomic_numbers_1hot
+            )
+            node_es_list.append(readout(node_feats).squeeze(-1))  # {[n_nodes, ], }
+
+        # Sum over interactions
+        node_inter_es = torch.sum(
+            torch.stack(node_es_list, dim=0), dim=0
+        )  # [n_nodes, ]
+        node_inter_es = self.scale_shift(node_inter_es)
+
+        # Sum over nodes in graph
+        inter_e = scatter_sum(
+            src=node_inter_es, index=data.batch, dim=-1, dim_size=data.num_graphs
+        )  # [n_graphs,]
+
+        # Add E_0 and (scaled) interaction energy
+        total_e = e0 + inter_e
+        forces = compute_forces(
+            energy=inter_e, positions=pos, training=self.training
+        )
+
+        return total_e, forces

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -57,6 +57,7 @@ class MACE(BaseModel):
         # support for gaussian basis.
         rbf: str = "bessel",
         num_rbf: int = 8,
+        rbf_hidden_channels: int = 64,
     ):
         super().__init__()
         self.cutoff = self.r_max = r_max
@@ -138,6 +139,7 @@ class MACE(BaseModel):
             # MACE considers a fixed `avg_num_neighbors`. We can either compute
             # this ~fixed statistic for OC20, or compute this value on-the-fly.
             avg_num_neighbors=avg_num_neighbors,
+            rbf_hidden_channels=rbf_hidden_channels,
         )
         self.interactions = torch.nn.ModuleList([inter])
 
@@ -174,6 +176,7 @@ class MACE(BaseModel):
                 target_irreps=interaction_irreps,
                 hidden_irreps=hidden_irreps_out,
                 avg_num_neighbors=avg_num_neighbors,
+                rbf_hidden_channels=rbf_hidden_channels,
             )
             self.interactions.append(inter)
             prod = EquivariantProductBasisBlock(
@@ -336,6 +339,7 @@ class ScaleShiftMACE(MACE):
         # support for gaussian basis.
         rbf: str = "bessel",
         num_rbf: int = 8,
+        rbf_hidden_channels: int = 64,
     ):
         super().__init__(
             num_atoms,
@@ -362,6 +366,7 @@ class ScaleShiftMACE(MACE):
             regress_forces,
             rbf=rbf,
             num_rbf=num_rbf,
+            rbf_hidden_channels=rbf_hidden_channels,
         )
         self.scale_shift = ScaleShiftBlock(
             scale=atomic_inter_scale, shift=atomic_inter_shift

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -50,7 +50,7 @@ class MACE(BaseModel):
         # per-element energy references currently initialized to 0s.
         atomic_energies=str,
         interaction_cls=RealAgnosticResidualInteractionBlock,
-        interaction_cls_first=AgnosticInteractionBlock,
+        interaction_cls_first=RealAgnosticResidualInteractionBlock,
         max_neighbors: int = 50,
         otf_graph: bool = True,
         use_pbc: bool = True,
@@ -304,7 +304,7 @@ class ScaleShiftMACE(MACE):
         gate=torch.nn.functional.silu,
         atomic_energies=str,
         interaction_cls=RealAgnosticResidualInteractionBlock,
-        interaction_cls_first=AgnosticInteractionBlock,
+        interaction_cls_first=RealAgnosticResidualInteractionBlock,
         max_neighbors: int = 500,
         otf_graph: bool = True,
         use_pbc: bool = True,

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -10,6 +10,7 @@ from ocpmodels.models.base import BaseModel
 
 from .blocks import (
     AtomicEnergiesBlock,
+    ForceBlock,
     LinearNodeEmbeddingBlock,
     LinearReadoutBlock,
     NonLinearReadoutBlock,
@@ -618,100 +619,3 @@ class InteractionEnergyMACE(MACE):
             return energy, forces
         else:
             raise NotImplementedError
-
-
-class ForceBlock(torch.nn.Module):
-    def __init__(self, hidden_irreps):
-        super().__init__()
-
-        # TODO(@abhshkdz): is this assertion needed?
-        self.hidden_irreps = hidden_irreps
-        assert hidden_irreps[0].dim * 3 == hidden_irreps[1].dim
-
-        l0_h = hidden_irreps[0].mul
-        l1_h = hidden_irreps[1].mul
-
-        self.output_network = torch.nn.ModuleList(
-            [
-                GatedEquivariantBlock(l0_h, l1_h, l1_h // 2),
-                GatedEquivariantBlock(l1_h // 2, l1_h // 2, 1),
-            ]
-        )
-
-        self.reset_parameters()
-
-    def reset_parameters(self):
-        for layer in self.output_network:
-            layer.reset_parameters()
-
-    def forward(self, node_feats):
-        # split node_feats into scalar and vector components.
-        x = node_feats[:, : self.hidden_irreps[0].dim]
-        vec = node_feats[
-            :,
-            self.hidden_irreps[0].dim : self.hidden_irreps[0].dim
-            + self.hidden_irreps[1].dim,
-        ]
-
-        vec = vec.reshape(vec.shape[0], self.hidden_irreps[1].mul, 3)
-        vec = vec.transpose(1, 2)
-
-        # pass it through the gated equivariant blocks.
-        for layer in self.output_network:
-            x, vec = layer(x, vec)
-
-        # return the vector components.
-        return vec.squeeze()
-
-
-# Implementation borrowed from TorchMD-Net
-class GatedEquivariantBlock(torch.nn.Module):
-    """Gated Equivariant Block as defined in Schütt et al. (2021):
-    Equivariant message passing for the prediction of tensorial properties and molecular spectra
-    """
-
-    def __init__(
-        self,
-        l0_channels,
-        l1_channels,
-        out_channels,
-    ):
-        super(GatedEquivariantBlock, self).__init__()
-        self.l0_channels = l0_channels
-        self.l1_channels = l1_channels
-        self.out_channels = out_channels
-
-        self.vec1_proj = torch.nn.Linear(l1_channels, l1_channels, bias=False)
-        self.vec2_proj = torch.nn.Linear(l1_channels, out_channels, bias=False)
-
-        self.update_net = torch.nn.Sequential(
-            torch.nn.Linear(
-                l0_channels + l1_channels,
-                l1_channels,
-            ),
-            torch.nn.SiLU(),
-            torch.nn.Linear(l1_channels, out_channels * 2),
-        )
-
-        self.act = torch.nn.SiLU()
-
-    def reset_parameters(self):
-        torch.nn.init.xavier_uniform_(self.vec1_proj.weight)
-        torch.nn.init.xavier_uniform_(self.vec2_proj.weight)
-        torch.nn.init.xavier_uniform_(self.update_net[0].weight)
-        self.update_net[0].bias.data.fill_(0)
-        torch.nn.init.xavier_uniform_(self.update_net[2].weight)
-        self.update_net[2].bias.data.fill_(0)
-
-    def forward(self, x, v):
-        # x is [num_nodes x l0_hidden_channels]
-        # v is [num_nodes x 3 x l1_hidden_channels]
-        vec1 = torch.norm(self.vec1_proj(v), dim=-2)
-        vec2 = self.vec2_proj(v)
-
-        x = torch.cat([x, vec1], dim=-1)
-        x, v = torch.split(self.update_net(x), self.out_channels, dim=-1)
-        v = v.unsqueeze(1) * vec2
-
-        x = self.act(x)
-        return x, v

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -16,7 +16,7 @@ from .blocks import (
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
     ScaleShiftBlock,
-    SpeciesAgnosticInteractionBlock,
+    SpeciesAgnosticResidualInteractionBlock,
 )
 from .mace_core.blocks import (
     AgnosticInteractionBlock,

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -54,6 +54,9 @@ class MACE(BaseModel):
         otf_graph: bool = True,
         use_pbc: bool = True,
         regress_forces: bool = True,
+        # support for gaussian basis.
+        rbf: str = "bessel",
+        num_rbf: int = 8,
     ):
         super().__init__()
         self.cutoff = self.r_max = r_max
@@ -75,11 +78,20 @@ class MACE(BaseModel):
         self.node_embedding = LinearNodeEmbeddingBlock(
             irreps_in=node_attr_irreps, irreps_out=node_feats_irreps
         )
-        self.radial_embedding = RadialEmbeddingBlock(
-            r_max=r_max,
-            num_bessel=num_bessel,
-            num_polynomial_cutoff=num_polynomial_cutoff,
-        )
+        if rbf == "bessel":
+            self.radial_embedding = RadialEmbeddingBlock(
+                r_max=r_max,
+                num_bessel=num_bessel,
+                num_polynomial_cutoff=num_polynomial_cutoff,
+                rbf="bessel",
+            )
+        elif rbf == "gaussian":
+            self.radial_embedding = RadialEmbeddingBlock(
+                r_max=r_max,
+                num_bessel=num_rbf,
+                num_polynomial_cutoff=num_polynomial_cutoff,
+                rbf="gaussian",
+            )
         edge_feats_irreps = o3.Irreps(f"{self.radial_embedding.out_dim}x0e")
 
         sh_irreps = o3.Irreps.spherical_harmonics(max_ell)
@@ -321,6 +333,9 @@ class ScaleShiftMACE(MACE):
         otf_graph: bool = True,
         use_pbc: bool = True,
         regress_forces: bool = True,
+        # support for gaussian basis.
+        rbf: str = "bessel",
+        num_rbf: int = 8,
     ):
         super().__init__(
             num_atoms,
@@ -345,6 +360,8 @@ class ScaleShiftMACE(MACE):
             otf_graph,
             use_pbc,
             regress_forces,
+            rbf=rbf,
+            num_rbf=num_rbf,
         )
         self.scale_shift = ScaleShiftBlock(
             scale=atomic_inter_scale, shift=atomic_inter_shift

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -18,6 +18,8 @@ from .blocks import (
     RealAgnosticResidualInteractionBlockV2,
     ScaleShiftBlock,
     SpeciesAgnosticResidualInteractionBlock,
+    IdentityResidualInteractionBlock,
+    EdgeGatedInteractionBlock,
 )
 from .mace_core.blocks import (
     AgnosticInteractionBlock,
@@ -66,6 +68,11 @@ class MACE(BaseModel):
         contraction_type: str = "v1",
         # source and target feature size when concatenating for edge conv.
         node_feats_down_irreps: str = "64x0e",
+        # parameters for edge gating.
+        edge_gates_irreps: o3.Irreps = o3.Irreps("0e"),
+        num_gates: int = 4,
+        multi_conv: bool = False,
+        exponential: bool = True,
     ):
         super().__init__()
         self.cutoff = self.r_max = r_max
@@ -150,6 +157,10 @@ class MACE(BaseModel):
             avg_num_neighbors=avg_num_neighbors,
             rbf_hidden_channels=rbf_hidden_channels,
             node_feats_down_irreps=o3.Irreps(node_feats_down_irreps),
+            edge_gates_irreps=edge_gates_irreps,
+            num_gates=num_gates,
+            multi_conv=multi_conv,
+            exponential=exponential,
         )
         self.interactions = torch.nn.ModuleList([inter])
 
@@ -192,6 +203,10 @@ class MACE(BaseModel):
                 avg_num_neighbors=avg_num_neighbors,
                 rbf_hidden_channels=rbf_hidden_channels,
                 node_feats_down_irreps=o3.Irreps(node_feats_down_irreps),
+                edge_gates_irreps=edge_gates_irreps,
+                num_gates=num_gates,
+                multi_conv=multi_conv,
+                exponential=exponential,
             )
             self.interactions.append(inter)
             prod = EquivariantProductBasisBlock(

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -198,8 +198,6 @@ class MACE(BaseModel):
             device=atomic_numbers.device
         ).scatter_(1, atomic_numbers.unsqueeze(1), 1.)
 
-        breakpoint()
-
         node_e0 = self.atomic_energies_fn(atomic_numbers_1hot)
         e0 = scatter_sum(
             src=node_e0, index=data.batch, dim=-1, dim_size=num_graphs

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -48,7 +48,7 @@ class MACE(BaseModel):
         # Defaults from OCP / https://github.com/ACEsuit/mace/blob/main/scripts/run_train.py
         gate=torch.nn.functional.silu,
         # per-element energy references currently initialized to 0s.
-        atomic_energies=np.array([0.0 for i in range(83)]),
+        atomic_energies=str,
         interaction_cls=RealAgnosticResidualInteractionBlock,
         interaction_cls_first=AgnosticInteractionBlock,
         max_neighbors: int = 50,
@@ -89,6 +89,10 @@ class MACE(BaseModel):
         )
 
         # Interactions and readout
+        if atomic_energies == "oc20tiny":
+            atomic_energies = np.array([-0.5789446234902406, 0.0, 0.0, 0.0, 0.0, -0.5789446234902277, 0.0, -0.28947231174511384, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -4.631556987921935, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -4.631556987921935, 0.0, 0.0, 0.0])
+        else:
+            atomic_energies = np.array([0. for i in range(83)])
         self.atomic_energies_fn = AtomicEnergiesBlock(atomic_energies)
 
         inter = interaction_cls_first(
@@ -274,10 +278,10 @@ class ScaleShiftMACE(MACE):
         atomic_inter_shift: float,
         # Defaults from OCP / https://github.com/ACEsuit/mace/blob/main/scripts/run_train.py
         gate=torch.nn.functional.silu,
-        atomic_energies=np.array([0.0 for i in range(83)]),
+        atomic_energies=str,
         interaction_cls=RealAgnosticResidualInteractionBlock,
         interaction_cls_first=AgnosticInteractionBlock,
-        max_neighbors: int = 50,
+        max_neighbors: int = 500,
         otf_graph: bool = True,
         use_pbc: bool = True,
         regress_forces: bool = True,
@@ -297,6 +301,14 @@ class ScaleShiftMACE(MACE):
             MLP_irreps,
             avg_num_neighbors,
             correlation,
+            gate,
+            atomic_energies,
+            interaction_cls,
+            interaction_cls_first,
+            max_neighbors,
+            otf_graph,
+            use_pbc,
+            regress_forces,
         )
         self.scale_shift = ScaleShiftBlock(
             scale=atomic_inter_scale, shift=atomic_inter_shift

--- a/ocpmodels/models/mace/models.py
+++ b/ocpmodels/models/mace/models.py
@@ -15,6 +15,7 @@ from .blocks import (
     LinearReadoutBlock,
     NonLinearReadoutBlock,
     RadialEmbeddingBlock,
+    RealAgnosticResidualInteractionBlockV2,
     ScaleShiftBlock,
     SpeciesAgnosticResidualInteractionBlock,
 )

--- a/ocpmodels/models/mace/radial.py
+++ b/ocpmodels/models/mace/radial.py
@@ -1,0 +1,81 @@
+import numpy as np
+import torch
+
+
+class BesselBasis(torch.nn.Module):
+    """
+    Klicpera, J.; Groß, J.; Günnemann, S. Directional Message Passing for Molecular Graphs; ICLR 2020.
+    Equation (7)
+    """
+
+    def __init__(self, r_max: float, num_basis=8, trainable=False):
+        super().__init__()
+
+        bessel_weights = (
+            np.pi
+            / r_max
+            * torch.linspace(
+                start=1.0,
+                end=num_basis,
+                steps=num_basis,
+                dtype=torch.get_default_dtype(),
+            )
+        )
+        if trainable:
+            self.bessel_weights = torch.nn.Parameter(bessel_weights)
+        else:
+            self.register_buffer("bessel_weights", bessel_weights)
+
+        self.register_buffer(
+            "r_max", torch.tensor(r_max, dtype=torch.get_default_dtype())
+        )
+        self.register_buffer(
+            "prefactor",
+            torch.tensor(np.sqrt(2.0 / r_max), dtype=torch.get_default_dtype()),
+        )
+
+    def forward(
+        self,
+        x: torch.Tensor,
+    ) -> torch.Tensor:  # [..., 1]
+        numerator = torch.sin(self.bessel_weights * x)  # [..., num_basis]
+        return self.prefactor * (numerator / x)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(r_max={self.r_max}, num_basis={len(self.bessel_weights)}, "
+            f"trainable={self.bessel_weights.requires_grad})"
+        )
+
+
+class PolynomialCutoff(torch.nn.Module):
+    """
+    Klicpera, J.; Groß, J.; Günnemann, S. Directional Message Passing for Molecular Graphs; ICLR 2020.
+    Equation (8)
+    """
+
+    p: torch.Tensor
+    r_max: torch.Tensor
+
+    def __init__(self, r_max: float, p=6):
+        super().__init__()
+        self.register_buffer("p", torch.tensor(p, dtype=torch.get_default_dtype()))
+        self.register_buffer(
+            "r_max", torch.tensor(r_max, dtype=torch.get_default_dtype())
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # yapf: disable
+        envelope = (
+                1.0
+                - ((self.p + 1.0) * (self.p + 2.0) / 2.0) * torch.pow(x / self.r_max, self.p)
+                + self.p * (self.p + 2.0) * torch.pow(x / self.r_max, self.p + 1)
+                - (self.p * (self.p + 1.0) / 2) * torch.pow(x / self.r_max, self.p + 2)
+        )
+        # yapf: enable
+
+        # noinspection PyUnresolvedReferences
+        return envelope * (x < self.r_max).type(torch.get_default_dtype())
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(p={self.p}, r_max={self.r_max})"

--- a/ocpmodels/models/mace/tools/torch_tools.py
+++ b/ocpmodels/models/mace/tools/torch_tools.py
@@ -1,0 +1,72 @@
+import logging
+from typing import Dict
+
+import numpy as np
+import torch
+
+TensorDict = Dict[str, torch.Tensor]
+
+
+def to_one_hot(indices: torch.Tensor, num_classes: int) -> torch.Tensor:
+    """
+    Generates one-hot encoding with <num_classes> classes from <indices>
+    :param indices: (N x 1) tensor
+    :param num_classes: number of classes
+    :param device: torch device
+    :return: (N x num_classes) tensor
+    """
+    shape = indices.shape[:-1] + (num_classes,)
+    oh = torch.zeros(shape, device=indices.device).view(shape)
+
+    # scatter_ is the in-place version of scatter
+    oh.scatter_(dim=-1, index=indices, value=1)
+
+    return oh.view(*shape)
+
+
+def count_parameters(module: torch.nn.Module) -> int:
+    return int(sum(np.prod(p.shape) for p in module.parameters()))
+
+
+def tensor_dict_to_device(td: TensorDict, device: torch.device) -> TensorDict:
+    return {k: v.to(device) for k, v in td.items()}
+
+
+def set_seeds(seed: int) -> None:
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def to_numpy(t: torch.Tensor) -> np.ndarray:
+    return t.cpu().detach().numpy()
+
+
+def init_device(device_str: str) -> torch.device:
+    if device_str == "cuda":
+        assert torch.cuda.is_available(), "No CUDA device available!"
+        logging.info(
+            f"CUDA version: {torch.version.cuda}, CUDA device: {torch.cuda.current_device()}"
+        )
+        torch.cuda.init()
+        return torch.device("cuda")
+
+    logging.info("Using CPU")
+    return torch.device("cpu")
+
+
+dtype_dict = {"float32": torch.float32, "float64": torch.float64}
+
+
+def set_default_dtype(dtype: str) -> None:
+    torch.set_default_dtype(dtype_dict[dtype])
+
+
+def get_complex_default_dtype():
+    default_dtype = torch.get_default_dtype()
+    if default_dtype == torch.float64:
+        return torch.complex128
+
+    if default_dtype == torch.float32:
+        return torch.complex64
+
+    raise NotImplementedError

--- a/ocpmodels/models/mace/utils.py
+++ b/ocpmodels/models/mace/utils.py
@@ -1,0 +1,120 @@
+import logging
+from typing import Tuple
+
+import numpy as np
+import torch
+import torch.nn
+import torch.utils.data
+
+from .tools.torch_tools import to_numpy
+from .mace_core.scatter import scatter_sum
+
+from .blocks import AtomicEnergiesBlock
+
+
+def compute_forces(
+    energy: torch.Tensor, positions: torch.Tensor, training=True
+) -> torch.Tensor:
+    gradient = torch.autograd.grad(
+        outputs=energy,  # [n_graphs, ]
+        inputs=positions,  # [n_nodes, 3]
+        grad_outputs=torch.ones_like(energy),
+        retain_graph=training,  # Make sure the graph is not destroyed during training
+        create_graph=training,  # Create graph for second derivative
+        only_inputs=True,  # Diff only w.r.t. inputs
+        allow_unused=True,
+    )[
+        0
+    ]  # [n_nodes, 3]
+    if gradient is None:
+        logging.warning("Gradient is None, padded with zeros")
+        return torch.zeros_like(positions)
+    return -1 * gradient
+
+
+def get_edge_vectors_and_lengths(
+    positions: torch.Tensor,  # [n_nodes, 3]
+    edge_index: torch.Tensor,  # [2, n_edges]
+    shifts: torch.Tensor,  # [n_edges, 3]
+    normalize: bool = False,
+    eps: float = 1e-9,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    sender, receiver = edge_index
+    # From ase.neighborlist:
+    # D = positions[j]-positions[i]+S.dot(cell)
+    # where shifts = S.dot(cell)
+    vectors = positions[receiver] - positions[sender] + shifts  # [n_edges, 3]
+    lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)  # [n_edges, 1]
+    if normalize:
+        vectors_normed = vectors / (lengths + eps)
+        return vectors_normed, lengths
+
+    return vectors, lengths
+
+
+def compute_mean_std_atomic_inter_energy(
+    data_loader: torch.utils.data.DataLoader,
+    atomic_energies: np.ndarray,
+) -> Tuple[float, float]:
+    atomic_energies_fn = AtomicEnergiesBlock(atomic_energies=atomic_energies)
+
+    avg_atom_inter_es_list = []
+
+    for batch in data_loader:
+        node_e0 = atomic_energies_fn(batch.node_attrs)
+        graph_e0s = scatter_sum(
+            src=node_e0, index=batch.batch, dim=-1, dim_size=batch.num_graphs
+        )
+        graph_sizes = batch.ptr[1:] - batch.ptr[:-1]
+        avg_atom_inter_es_list.append(
+            (batch.energy - graph_e0s) / graph_sizes
+        )  # {[n_graphs], }
+
+    avg_atom_inter_es = torch.cat(avg_atom_inter_es_list)  # [total_n_graphs]
+    mean = to_numpy(torch.mean(avg_atom_inter_es)).item()
+    std = to_numpy(torch.std(avg_atom_inter_es)).item()
+
+    return mean, std
+
+
+def compute_mean_rms_energy_forces(
+    data_loader: torch.utils.data.DataLoader,
+    atomic_energies: np.ndarray,
+) -> Tuple[float, float]:
+    atomic_energies_fn = AtomicEnergiesBlock(atomic_energies=atomic_energies)
+
+    atom_energy_list = []
+    forces_list = []
+
+    for batch in data_loader:
+        node_e0 = atomic_energies_fn(batch.node_attrs)
+        graph_e0s = scatter_sum(
+            src=node_e0, index=batch.batch, dim=-1, dim_size=batch.num_graphs
+        )
+        graph_sizes = batch.ptr[1:] - batch.ptr[:-1]
+        atom_energy_list.append(
+            (batch.energy - graph_e0s) / graph_sizes
+        )  # {[n_graphs], }
+        forces_list.append(batch.forces)  # {[n_graphs*n_atoms,3], }
+
+    atom_energies = torch.cat(atom_energy_list, dim=0)  # [total_n_graphs]
+    forces = torch.cat(forces_list, dim=0)  # {[total_n_graphs*n_atoms,3], }
+
+    mean = to_numpy(torch.mean(atom_energies)).item()
+    rms = to_numpy(torch.sqrt(torch.mean(torch.square(forces)))).item()
+
+    return mean, rms
+
+
+def compute_avg_num_neighbors(data_loader: torch.utils.data.DataLoader) -> float:
+    num_neighbors = []
+
+    for batch in data_loader:
+        _, receivers = batch.edge_index
+        _, counts = torch.unique(receivers, return_counts=True)
+        num_neighbors.append(counts)
+
+    avg_num_neighbors = torch.mean(
+        torch.cat(num_neighbors, dim=0).type(torch.get_default_dtype())
+    )
+    return to_numpy(avg_num_neighbors).item()

--- a/ocpmodels/modules/evaluator.py
+++ b/ocpmodels/modules/evaluator.py
@@ -38,7 +38,9 @@ class Evaluator:
             "forces_mae",
             "forces_cos",
             "forces_magnitude",
+            "forces_mse",
             "energy_mae",
+            "energy_per_atom_mse",
             "energy_force_within_threshold",
         ],
         "is2rs": [
@@ -114,6 +116,13 @@ def energy_mae(prediction, target):
 
 def energy_mse(prediction, target):
     return squared_error(prediction["energy"], target["energy"])
+
+
+def energy_per_atom_mse(prediction, target):
+    return squared_error(
+        prediction["energy"] / prediction["natoms"],
+        target["energy"] / target["natoms"]
+    )
 
 
 def forcesx_mae(prediction, target):

--- a/ocpmodels/trainers/eval_mace_chkpts_trainer.py
+++ b/ocpmodels/trainers/eval_mace_chkpts_trainer.py
@@ -1,0 +1,60 @@
+import os
+import errno
+import logging
+
+import torch
+import torch.optim as optim
+
+from ocpmodels.common.registry import registry
+from ocpmodels.common.utils import load_state_dict
+from ocpmodels.trainers.mace_trainer import MACETrainer
+
+
+@registry.register_trainer("eval_mace_chkpts_trainer")
+class EvalMACECheckpointsTrainer(MACETrainer):
+    def load_checkpoint(self, checkpoint_path):
+        if not os.path.isfile(checkpoint_path):
+            raise FileNotFoundError(
+                errno.ENOENT, "Checkpoint file not found", checkpoint_path
+            )
+
+        logging.info(f"Loading checkpoint from: {checkpoint_path}")
+        map_location = torch.device("cpu") if self.cpu else self.device
+        checkpoint = torch.load(checkpoint_path, map_location=map_location)
+        self.epoch = checkpoint.get("epoch", 0)
+        self.step = checkpoint.get("step", 0)
+        self.best_val_metric = checkpoint.get("best_val_metric", None)
+        self.primary_metric = checkpoint.get("primary_metric", None)
+
+        # Match the "module." count in the keys of model and checkpoint state_dict
+        # DataParallel model has 1 "module.",  DistributedDataParallel has 2 "module."
+        # Not using either of the above two would have no "module."
+
+        ckpt_key_count = next(iter(checkpoint["model"])).count("module")
+        mod_key_count = next(iter(self.model.state_dict())).count("module")
+        key_count_diff = mod_key_count - ckpt_key_count
+
+        if key_count_diff > 0:
+            new_dict = {
+                key_count_diff * "module." + k: v
+                for k, v in checkpoint["model"].items()
+            }
+        elif key_count_diff < 0:
+            new_dict = {
+                k[len("module.") * abs(key_count_diff) :]: v
+                for k, v in checkpoint["model"].items()
+            }
+        else:
+            new_dict = checkpoint["model"]
+
+        strict = self.config["task"].get("strict_load", True)
+        load_state_dict(self.model, new_dict, strict=strict)
+
+        if "optimizer" in checkpoint:
+            self.optimizer.load_state_dict(checkpoint["optimizer"])
+        if "lr_scheduler" in checkpoint and checkpoint["lr_scheduler"] is not None:
+            self.scheduler.scheduler.load_state_dict(checkpoint["lr_scheduler"])
+        if "ema" in checkpoint and checkpoint["ema"] is not None:
+            self.ema.load_state_dict(checkpoint["ema"])
+        else:
+            self.ema = None

--- a/ocpmodels/trainers/mace_trainer.py
+++ b/ocpmodels/trainers/mace_trainer.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import torch.optim as optim
+
+from ocpmodels.common.registry import registry
+from ocpmodels.trainers import ForcesTrainer
+
+
+@registry.register_trainer("mace_trainer")
+class MACETrainer(ForcesTrainer):
+    # Following optimizer / weight decay defaults from
+    # https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/scripts/run_train.py#L210
+    def load_optimizer(self):
+        optimizer = self.config["optim"].get("optimizer", "AdamW")
+        optimizer = getattr(optim, optimizer)
+
+        if self.config["optim"].get("weight_decay", 0) > 0:
+
+            int_params_decay = []
+            int_params_no_decay = []
+            for name, param in self._unwrapped_model.interactions.named_parameters():
+                if "linear.weight" in name or "skip_tp_full.weight" in name:
+                    int_params_decay += [param]
+                else:
+                    int_params_no_decay += [param]
+
+            self.optimizer = optimizer(
+                params=[
+                    {
+                        "name": "embedding",
+                        "params": self._unwrapped_model.node_embedding.parameters(),
+                        "weight_decay": 0.0,
+                    },
+                    {
+                        "name": "interactions_decay",
+                        "params": int_params_decay,
+                        "weight_decay": self.config["optim"]["weight_decay"],
+                    },
+                    {
+                        "name": "interactions_no_decay",
+                        "params": int_params_no_decay,
+                        "weight_decay": 0.0,
+                    },
+                    {
+                        "name": "products",
+                        "params": self._unwrapped_model.products.parameters(),
+                        "weight_decay": self.config["optim"]["weight_decay"],
+                    },
+                    {
+                        "name": "readouts",
+                        "params": self._unwrapped_model.readouts.parameters(),
+                        "weight_decay": 0.0,
+                    },
+                ],
+                lr=self.config["optim"]["lr_initial"],
+                **self.config["optim"].get("optimizer_params", {}),
+            )
+        else:
+            self.optimizer = optimizer(
+                params=self.model.parameters(),
+                lr=self.config["optim"]["lr_initial"],
+                **self.config["optim"].get("optimizer_params", {}),
+            )

--- a/ocpmodels/trainers/mace_trainer.py
+++ b/ocpmodels/trainers/mace_trainer.py
@@ -1,10 +1,3 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
-
 import torch.optim as optim
 
 from ocpmodels.common.registry import registry

--- a/ocpmodels/trainers/mace_trainer.py
+++ b/ocpmodels/trainers/mace_trainer.py
@@ -1,6 +1,8 @@
+import torch
 import torch.optim as optim
 
 from ocpmodels.common.registry import registry
+from ocpmodels.modules.loss import DDPLoss, PerAtomMSELossEnergy, MSELossForces
 from ocpmodels.trainers import ForcesTrainer
 
 
@@ -59,3 +61,61 @@ class MACETrainer(ForcesTrainer):
                 lr=self.config["optim"]["lr_initial"],
                 **self.config["optim"].get("optimizer_params", {}),
             )
+
+    def load_loss(self):
+        self.loss_fn = {}
+        self.loss_fn["energy"] = DDPLoss(PerAtomMSELossEnergy())
+        self.loss_fn["force"] = DDPLoss(MSELossForces())
+
+    def _compute_loss(self, out, batch_list):
+        assert self.config["task"].get("train_on_free_atoms", False)
+        assert self.config["model_attributes"].get("regress_forces", False)
+
+        loss = []
+
+        natoms = torch.cat(
+            [
+                batch.natoms.to(self.device)
+                for batch in batch_list
+            ]
+        )
+
+        # Energy loss.
+        energy_target = torch.cat(
+            [batch.y.to(self.device) for batch in batch_list], dim=0
+        )
+        if self.normalizer.get("normalize_labels", False):
+            energy_target = self.normalizers["target"].norm(energy_target)
+        energy_mult = self.config["optim"].get("energy_coefficient", 1)
+        loss.append(
+            energy_mult * self.loss_fn["energy"](out["energy"], energy_target, natoms)
+        )
+
+        # Force loss.
+        force_target = torch.cat(
+            [batch.force.to(self.device) for batch in batch_list], dim=0
+        )
+        if self.normalizer.get("normalize_labels", False):
+            force_target = self.normalizers["grad_target"].norm(
+                force_target
+            )
+
+        force_mult = self.config["optim"].get("force_coefficient", 100)
+
+        fixed = torch.cat(
+            [batch.fixed.to(self.device) for batch in batch_list]
+        )
+        mask = fixed == 0
+        loss.append(
+            force_mult
+            * self.loss_fn["force"](
+                out["forces"][mask], force_target[mask]
+            )
+        )
+
+        # Sanity check to make sure the compute graph is correct.
+        for lc in loss:
+            assert hasattr(lc, "grad_fn")
+
+        loss = sum(loss)
+        return loss

--- a/scripts/compute_mace_stats.py
+++ b/scripts/compute_mace_stats.py
@@ -1,0 +1,94 @@
+from ocpmodels.datasets import OC22LmdbDataset, data_list_collater
+from ocpmodels.models import BaseModel
+from torch.utils.data import DataLoader
+from torch_scatter import scatter
+from tqdm import tqdm
+import numpy as np
+import torch
+
+
+dset_path = "/checkpoint/bmwood/oc20_small/oc20_xxs_dataset/lmdb/train"
+oc20_ref = "/checkpoint/janlan/ocp/other_data/final_ref_energies_02_07_2021.pkl"
+cutoff = 6.0
+max_neighbors = 500
+
+# adapted from https://github.com/ACEsuit/mace/blob/f304c07bbafd651f5a52a447c954f1ef561d42e2/mace/data/utils.py#L170
+def compute_average_E0s(dl: DataLoader):
+    len_dset = len(dl.dataset)
+    len_zs = 83
+
+    A = np.zeros((len_dset, len_zs))
+    B = np.zeros(len_dset)
+
+    for i, batch in tqdm(enumerate(dl)):
+        breakpoint()
+        if i == len(dl) - 1: sz = batch.y.shape[0]
+        else: sz = dl.batch_size
+
+        B[i * dl.batch_size : i * dl.batch_size + sz] = batch.y
+        for j, do in enumerate(batch.to_data_list()):
+            for z in range(len_zs):
+                A[i * dl.batch_size + j, z] = np.count_nonzero(do.atomic_numbers - 1 == z)  # -1 because of 0-indexing
+
+
+    E0s = np.linalg.lstsq(A, B, rcond=None)[0]
+    return E0s
+
+
+if __name__ == "__main__":
+    cfg = {
+        "src": dset_path,
+        "oc20_ref": oc20_ref,
+        "total_energy": True,
+        "otf_graph": True,
+    }
+    dset = OC22LmdbDataset(cfg)
+
+    dl = DataLoader(
+        dset,
+        batch_size=32,
+        shuffle=False,
+        collate_fn=data_list_collater,
+        num_workers=32,
+        pin_memory=True,
+    )
+
+    E0s = compute_average_E0s(dl)
+    print("E0s", E0s.tolist())
+
+    E0s = torch.tensor(E0s)
+
+    model = BaseModel()
+
+    e, f, n, nbrs = [], [], [], []
+
+    for i, batch in tqdm(enumerate(dl)):
+
+        n.append(batch.natoms)
+        f.append(batch.force)
+
+        graph = model.generate_graph(
+            batch,
+            cutoff=cutoff,
+            max_neighbors=max_neighbors,
+            use_pbc=True,
+            otf_graph=True,
+        )
+
+        nbrs.append(torch.div(graph[-1], batch.natoms))
+
+        # compute interaction energies
+        atom_e0 = E0s[batch.atomic_numbers.long() - 1]
+        graph_e0 = scatter(src=atom_e0, index=batch.batch, dim=-1)
+
+        e.append(batch.y - graph_e0)
+
+    e = torch.cat(e, dim=0)
+    f = torch.cat(f, dim=0)
+    n = torch.cat(n, dim=0)
+    nbrs = torch.cat(nbrs, dim=0)
+
+    print("interaction energy", e.mean().item())
+    print("interaction energy per atom", torch.div(e, n).mean().item())
+    print("forces rms", torch.sqrt(torch.mean(torch.square(f))).item())
+    print("neighbors", nbrs.mean().item())

--- a/scripts/run_train.sh
+++ b/scripts/run_train.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+PATH=/checkpoint/abhshkdz/local/bin:/private/home/abhshkdz/.local/bin:/public/apps/anaconda3/2020.11/condabin:/public/apps/anaconda3/2020.11/bin:/public/apps/gcc/7.1.0/bin:/public/apps/cuda/11.6/bin:/usr/local/cuda/bin:/opt/bin:/usr/local/cuda/bin:/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/public/slurm/20.11.5/bin:/public/slurm/20.11.5/sbin
+
+################################################################################
+
+ROOT_DIR="/private/home/abhshkdz/projects/mace-ocp"
+
+# name your run; it'll show up on wandb by this name
+IDENTIFIER="mace_0127"
+
+# yaml config
+CONFIG_YML=configs/s2ef/2M/mace/base_0127.yml
+
+# directory where slurm logs will get saved
+LOG_DIR=/checkpoint/abhshkdz/ocp_oct1_logs
+
+# conda env
+ENV=/private/home/abhshkdz/.conda/envs/ocp-mace-2022dec20
+
+# running locally?
+LOCAL_RUN=false
+
+# slurm?
+PARTITION=ocp,learnaccel
+NODES=2
+
+# initializing from a checkpoint?
+# CHECKPOINT_PATH=
+
+MODE=train
+
+# launching a sweep?
+# SWEEP_YML=experimental/abhshkdz/gnoc_v2/configs/2M/101103_no_loss_high_fmax_sweep.yml
+
+################################################################################
+
+PYTHON=$ENV/bin/python
+
+_setArgs(){
+    while [ "$1" != "" ]; do
+        case $1 in
+            "--local")
+                IDENTIFIER="debug"
+                LOCAL_RUN=true
+                ;;
+        esac
+        shift
+    done
+}
+
+_setArgs $*
+
+################################################################################
+
+LAUNCH_ARGS="--config-yml $CONFIG_YML \
+    --identifier $IDENTIFIER \
+    --logdir $LOG_DIR \
+    --seed 1 \
+    --distributed \
+    --mode $MODE"
+
+# LAUNCH_ARGS="$LAUNCH_ARGS --amp"
+
+# with pretrained checkpoint
+if [ ${CHECKPOINT_PATH+x} ] ; then
+    LAUNCH_ARGS="$LAUNCH_ARGS --checkpoint $CHECKPOINT_PATH"
+fi
+
+# with sweep params
+if [ ${SWEEP_YML+x} ] ; then
+    LAUNCH_ARGS="$LAUNCH_ARGS --sweep-yml $SWEEP_YML"
+fi
+
+if [ "$LOCAL_RUN" = true ] ; then
+    # local run
+    LAUNCH_ARGS="$LAUNCH_ARGS --debug"
+    $PYTHON -u -m torch.distributed.launch --nproc_per_node=1 main.py $LAUNCH_ARGS
+else
+    # submit to slurm
+    LAUNCH_ARGS="$LAUNCH_ARGS --submit \
+        --slurm-mem 480 \
+        --slurm-partition $PARTITION \
+        --num-nodes $NODES \
+        --num-gpus 8"
+    $PYTHON $ROOT_DIR/main.py $LAUNCH_ARGS
+fi


### PR DESCRIPTION
Hey all, here's an initial attempt at integrating the MACE model into the OCP codebase.

Checklist of some of the code changes and details we discussed:

- [x] Layer-wise weight decay with default set to 5.e-7 (following [this](https://github.com/ACEsuit/mace/blob/5470b632d839358faed4e9c97f67fece1b558962/scripts/run_train.py#L211-L249)) 
- [x] EMA with default decay set to 0.99 (following [this](https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L285))
- [x] AdamW with `amsgrad = True`, sweeping over `initial_lr = [1.e-2, 5.e-3, 1.e-3]`
- [x] Gradients clipped to max norm = 10 (following [this](https://github.com/ACEsuit/mace/blob/main/mace/tools/arg_parser.py#L321))
- [x] Switched off ocp `normalize_labels` since the `ScaleShiftBlock` in MACE model does the same thing.
- [x] Reduce weight decay to `1.e-10` or lower.
- [x] Correct scale and shift statistics. Scale should be RMS forces, and shift should be mean energy per atom, both computed on the training set.
- [ ] SWA scheduler with energy / force loss coefficient switch
- [x] E0 initialized to per-atom fitted energies (currently initialized to 0s)
- [x] Differences b/w the [ocp force loss](https://github.com/ACEsuit/mace-ocp/blob/main/ocpmodels/modules/loss.py) (mean L2) vs. [mace force loss](https://github.com/ACEsuit/mace/blob/main/mace/modules/loss.py) (MSE).

On code organization, I've tried to use as much of [`ACEsuit/mace-core`](https://github.com/ACEsuit/mace-core) as possible, but there's still quite a bit of duplication between this and [`ACEsuit/mace`](https://github.com/ACEsuit/mace), which is non-ideal. Let me know if you guys have thoughts on how to better organize this and/or feel free to directly push to this branch.

I've kicked off a few training runs on the OC20 S2EF-2M set with the above changes. Would be great to also establish parity on the smaller dataset.